### PR TITLE
Disable plain jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,10 @@ java {
 	sourceCompatibility = JavaVersion.VERSION_21
 }
 
+tasks.jar {
+	enabled = false
+}
+
 repositories {
 	mavenCentral()
 }


### PR DESCRIPTION
* if you don't disable this task, gradle will produce both the plain jar and the spring boot jar; unfortunately, buildpacks can't guess which one to pick; so that's better to remove the ambiguity
* you can see this in action in the samples: https://github.com/paketo-buildpacks/samples/blob/main/java/gradle/build.gradle#L12